### PR TITLE
Fix disk not being grown to the full capacity of the hard-drive

### DIFF
--- a/scripts/install_microos.sh
+++ b/scripts/install_microos.sh
@@ -6,5 +6,12 @@ wget --timeout=5 https://ftp.gwdg.de/pub/opensuse/repositories/devel:/kubic:/ima
 # write image to internal disk /dev/sda
 qemu-img convert -p -f qcow2 -O host_device $(ls -a | grep -ie '^opensuse.*microos.*qcow2$') /dev/sda
 
+# grow the sda4 partition to the end of the disk
+parted -s /dev/sda resizepart 4 100%
+
+# sda4 is mounted to /var on the btfs filesystem, first mount it, then grow the filesystem
+mount /dev/sda4 /var
+btrfs filesystem resize max /var
+
 # reboot
 sleep 2; reboot


### PR DESCRIPTION
Hey @ifeulner,

Currently, even if we choose to build an image for cx21 which has 40GB. The disk remains with a total of 21 GB, which is the default MicroOS disk size.

The changes introduced here, make sure to grow the sda4 (/var) to its full capacity.

_This is inspired by what were doing at the very beginning of this project, see https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/blob/microOS-k3s-rpm/locals.tf_